### PR TITLE
Changes needed to support the latest babel.

### DIFF
--- a/src/scanner.es6
+++ b/src/scanner.es6
@@ -3,6 +3,9 @@
 
 module.exports = (function(){
   "use strict";
+  
+  // Needed to support RegExp.prototype.flags
+  require("babel-polyfill");
 
   const {def} = require('./sesshim.es6');
   const {re} = require('./qregexp.es6');

--- a/src/scannerless.es6
+++ b/src/scannerless.es6
@@ -7,8 +7,7 @@ module.exports = (function(){
   const {def} = require('./sesshim.es6');
   const {FAIL, EOF,
     SPACE_RE, NUMBER_RE, STRING_RE, IDENT_RE,
-    LINE_COMMENT_RE, stickyRE,
-    Pos, Packratter} = require('./scanner.es6');
+    LINE_COMMENT_RE, stickyRE,Packratter} = require('./scanner.es6');
   const {quasifyParser, bnf} = require('./bootbnf.es6');
 
   /**

--- a/src/scannerless.es6
+++ b/src/scannerless.es6
@@ -7,7 +7,7 @@ module.exports = (function(){
   const {def} = require('./sesshim.es6');
   const {FAIL, EOF,
     SPACE_RE, NUMBER_RE, STRING_RE, IDENT_RE,
-    LINE_COMMENT_RE, stickyRE,Packratter} = require('./scanner.es6');
+    LINE_COMMENT_RE, stickyRE, Packratter} = require('./scanner.es6');
   const {quasifyParser, bnf} = require('./bootbnf.es6');
 
   /**

--- a/src/sesshim.es6
+++ b/src/sesshim.es6
@@ -20,7 +20,7 @@
 module.exports = (function(){
   "use strict";
 
-  const to5 = require('babel');
+  const to5 = require('babel-core');
 
   /**
    * The faux version of SES's <tt>def</tt> is currently just a
@@ -62,7 +62,7 @@ module.exports = (function(){
 })
 //# sourceURL=data:${encodeURIComponent(exprSrc)}
 `;
-    closedFuncSrc = to5.transform(closedFuncSrc).code;
+    closedFuncSrc = to5.transform(closedFuncSrc, { presets: ['es2015'] }).code;
     const closedFunc = (1,eval)(closedFuncSrc);
     return closedFunc(...names.map(n => env[n]));
   }

--- a/testbnfmain.js
+++ b/testbnfmain.js
@@ -7,8 +7,7 @@
 module.exports = (function(){
   "use strict";
 
-  require('babel');
-  require('babel/register');
+  require('babel-register')({ presets: [ 'es2015' ] });
 
   var sesshim = require('./src/sesshim.es6');
   var def = sesshim.def;

--- a/testmicrosesmain.js
+++ b/testmicrosesmain.js
@@ -7,8 +7,7 @@
 module.exports = (function(){
   "use strict";
 
-  require('babel');
-  require('babel/register');
+  require('babel-register')({ presets: [ 'es2015' ] });
 
   var sesshim = require('./src/sesshim.es6');
   var def = sesshim.def;
@@ -16,7 +15,7 @@ module.exports = (function(){
   var microses = microsesMod.microses;
 
   console.log('----------');
-  const ast = microses`2+3;`;
+  var ast = microses`2+3;`;
   console.log(JSON.stringify(ast));
 
   return def({});


### PR DESCRIPTION
The latest babel that you get via npm install (babel 6) does not by default rewrite ES6 -> ES5.  Instead
the specific sets of rewriters you desire need to be require()'ed.  Also loads the polyfill needed by
RE.flags and some minor cleanup (use of const in a js file vs es6 file).
